### PR TITLE
feat(listbar): add listbar commands property decorator

### DIFF
--- a/projects/platform-terminal/src/lib/elements-registry.ts
+++ b/projects/platform-terminal/src/lib/elements-registry.ts
@@ -25,4 +25,8 @@ export const elementPropertyDecorators: Map<string, Map<string, ElementPropertyD
   .set('table', new Map([
     ['rows', (element: Widgets.TableElement, name, value) => element.setRows(value)],
     ['data', (element: Widgets.TableElement, name, value) => element.setData(value)],
+  ]))
+  .set('listbar', new Map([
+    ['items', (element: Widgets.ListbarElement, name, value) => { element.setItems(value); }],
+    ['commands', (element: Widgets.ListbarElement, name, value) => { element.setItems(value); }],
   ]));


### PR DESCRIPTION
Template:
`<listbar [commands]="items" width="50%" height="50%"></listbar>`
or
`<listbar [items]="items" width="50%" height="50%"></listbar>`

TS:
```
items: Widgets.Types.ListbarCommand[] = [
  {
    keys: [ '\u0061' ],
    name: 'Command A',
    callback: () => {  },
  } as any
];
```
